### PR TITLE
Initialize AWS VPC Stack with Configurable Network Configuration


### DIFF
--- a/bin/aws-vpc.ts
+++ b/bin/aws-vpc.ts
@@ -1,8 +1,67 @@
 #!/usr/bin/env node
+import 'source-map-support/register';
 
 import * as cdk from 'aws-cdk-lib';
-import { AwsVpcStack } from '../lib/aws-vpc-stack';
+import * as dotenv from 'dotenv';
+import { booleanParser, checkEnvVariables } from '../utils/check-environment-variable';
 
+import { ApplyTags } from '../utils/apply-tag';
+import { Aspects } from 'aws-cdk-lib';
+import { AwsSolutionsChecks } from 'cdk-nag';
+import { AwsVpcStack } from '../lib/aws-vpc-stack';
+import { AwsVpcStackProps } from '../lib/AwsVpcStackProps';
+
+dotenv.config(); // Load environment variables from .env file
 const app = new cdk.App();
-new AwsVpcStack(app, 'AwsVpcStack', {
+
+const appAspects = Aspects.of(app);
+
+// check APP_NAME variable
+checkEnvVariables('APP_NAME',
+    'CDK_DEPLOY_REGIONS',
+    'ENVIRONMENTS',
+    'VPC_SUBNET_TYPE',
+    'NAT_GATEWAYS',
+    'VPC_CIDR',
+    'VPC_MAX_AZS',
+    'OWNER',
+);
+
+const { CDK_DEFAULT_ACCOUNT: account } = process.env;
+
+const cdkRegion = process.env.CDK_DEPLOY_REGION;
+const deployEnvironment = process.env.ENVIRONMENT;
+
+const appName = process.env.APP_NAME!;
+const owner = process.env.OWNER;
+
+// check best practices based on AWS Solutions Security Matrix
+appAspects.add(new AwsSolutionsChecks());
+
+appAspects.add(new ApplyTags({
+    environment: deployEnvironment as 'development' | 'staging' | 'production' | 'feature',
+    project: appName,
+    owner: owner,
+}));
+
+const stackProps: AwsVpcStackProps = {
+    resourcePrefix: `${appName}-${deployEnvironment}`,
+    env: {
+        region: cdkRegion,
+        account,
+    },
+    deployRegion: cdkRegion,
+    deployEnvironment,
+    appName,
+    vpcSubnetType: process.env.VPC_SUBNET_TYPE!,
+    NAT_GATEWAYS: parseInt(process.env.NAT_GATEWAYS!),
+    VPC_CIDR: process.env.VPC_CIDR!,
+    VPC_MAX_AZS: parseInt(process.env.VPC_MAX_AZS!),
+};
+new AwsVpcStack(app, `AwsVpcStack`, {
+    ...stackProps,
+    stackName: `${appName}-${deployEnvironment}-${cdkRegion}-AwsVpcStack`,
+    description: `AwsVpcStack for ${appName} in ${cdkRegion} ${deployEnvironment}.`,
 });
+
+app.synth();

--- a/lib/AwsVpcStackProps.ts
+++ b/lib/AwsVpcStackProps.ts
@@ -1,0 +1,12 @@
+import { StackProps } from "aws-cdk-lib";
+
+export interface AwsVpcStackProps extends StackProps {
+    readonly resourcePrefix: string;
+    readonly deployRegion: string | undefined;
+    readonly deployEnvironment: string;
+    readonly appName: string;
+    readonly vpcSubnetType: string;
+    readonly NAT_GATEWAYS: number;
+    readonly VPC_CIDR: string;
+    readonly VPC_MAX_AZS: number;
+}

--- a/lib/aws-vpc-stack.ts
+++ b/lib/aws-vpc-stack.ts
@@ -1,8 +1,109 @@
 import * as cdk from 'aws-cdk-lib';
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as logs from "aws-cdk-lib/aws-logs";
 import { Construct } from 'constructs';
+import { AwsVpcStackProps } from './AwsVpcStackProps';
+import { parseVpcSubnetType } from '../utils/vpc-type-parser';
+import { NagSuppressions } from 'cdk-nag';
 
 export class AwsVpcStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props: AwsVpcStackProps) {
     super(scope, id, props);
+
+    const vpcName = `${props.resourcePrefix}-VPC`;
+    const vpcSubnetType = parseVpcSubnetType(props.vpcSubnetType);
+
+    // print out vpcSubnetType
+    console.log(`VPC Subnet Type: ${vpcSubnetType}`);
+
+    // print out maxAzs
+    console.log(`Max Availability Zones: ${props.VPC_MAX_AZS}`);
+
+    // print out NAT gateways
+    console.log(`NAT Gateways: ${props.NAT_GATEWAYS}`);
+
+    // print out VPC CIDR
+    console.log(`VPC CIDR: ${props.VPC_CIDR}`);
+
+    const cxVpc = new ec2.Vpc(this, vpcName, {
+            ipAddresses: ec2.IpAddresses.cidr(props.VPC_CIDR), //IPs in Range - 65,536
+            natGateways: props.NAT_GATEWAYS, // Isolated Subnets do not route traffic to the Internet (in this VPC), and as such, do not require NAT gateways.
+            maxAzs: props.VPC_MAX_AZS, // for high availability
+            subnetConfiguration: [
+                {
+                    name: `${props.resourcePrefix}-PUBLIC`,
+                    subnetType: ec2.SubnetType.PUBLIC,
+                    cidrMask: 24, //IPs in Range - 256
+                },
+                {
+                    name: `${props.resourcePrefix}-${vpcSubnetType}`,
+                    subnetType: vpcSubnetType,
+                    cidrMask: 24, //IPs in Range - 256
+                },
+            ],
+            enableDnsHostnames: true,
+            enableDnsSupport: true,
+    });
+
+    // apply removal policy to all vpc and subnet resources
+    cxVpc.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    for (const subnet of cxVpc.privateSubnets) {
+        subnet.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    }
+    for (const subnet of cxVpc.isolatedSubnets) {
+        subnet.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    }
+    for (const subnet of cxVpc.publicSubnets) {
+        subnet.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    }
+
+    const vpcFlowLogRole = new iam.Role(this, `${props.resourcePrefix}-RoleVpcFlowLogs`, {
+        assumedBy: new iam.ServicePrincipal("vpc-flow-logs.amazonaws.com"),
+        inlinePolicies: {
+            CloudWatchFullAccessPolicy: new iam.PolicyDocument({
+                statements: [
+                    new iam.PolicyStatement({
+                        actions: [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents",
+                            "logs:DescribeLogGroups",
+                            "logs:DescribeLogStreams",
+                        ],
+                        resources: ["*"],
+                    }),
+                ],
+            }),
+        },
+    });
+
+    // Suppress cdk-nag rule for wildcard permissions
+    NagSuppressions.addResourceSuppressions(
+        vpcFlowLogRole,
+        [
+            {
+                id: 'AwsSolutions-IAM5',
+                reason: 'The wildcard permissions are required for VPC flow logs to function correctly.',
+            },
+        ],
+        true
+    );
+
+    const vpcFlowLogGroup = new logs.LogGroup(this, `${props.resourcePrefix}-VpcFlowLogGroup`, {
+        retention: logs.RetentionDays.ONE_MONTH,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    new logs.LogStream(this, `${props.resourcePrefix}-VpcFlowLogStream`, {
+        logGroup: vpcFlowLogGroup,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    new ec2.FlowLog(this, `${props.resourcePrefix}-VpcFlowLog`, {
+        resourceType: ec2.FlowLogResourceType.fromVpc(cxVpc),
+        destination: ec2.FlowLogDestination.toCloudWatchLogs(vpcFlowLogGroup, vpcFlowLogRole),
+        trafficType: ec2.FlowLogTrafficType.ALL,
+    });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.171.1",
+        "cdk-nag": "^2.34.12",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.5"
       },
@@ -25,6 +26,11 @@
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
+      },
+      "peerDependencies": {
+        "aws-cdk": "2.171.1",
+        "aws-cdk-lib": "2.171.1",
+        "constructs": "^10.4.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1886,6 +1892,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cdk-nag": {
+      "version": "2.34.12",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.12.tgz",
+      "integrity": "sha512-81Be6u+MXA0vbR0TfSCkw5OSoYSZK/7WMZUjF/0nRqc7q1fLLpwetEaNUU7xsx1j97aIIN0ehH5NOXtbA0k7tQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.156.0",
+        "constructs": "^10.0.5"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.171.1",
+    "cdk-nag": "^2.34.12",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.5"
   },


### PR DESCRIPTION
### **PR Type**
Feature, Configuration


___

### **PR Description**
This Pull Request initializes an AWS VPC (Virtual Private Cloud) stack using AWS CDK with the following key changes:
- Added `AwsVpcStackProps` interface to define custom VPC stack properties
- Implemented `AwsVpcStack` with configurable VPC settings from environment variables
- Integrated `cdk-nag` for AWS best practices and security checks
- Configured VPC with:
  - Customizable CIDR range
  - Configurable number of NAT gateways
  - Multiple subnet types (public and private/isolated)
  - Flow logs for network monitoring
- Added environment variable validation and parsing utilities
- Implemented tagging and removal policies for VPC resources

