### PR TITLE
Upgrade AWS CDK and Related Dependencies


### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-vpc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-vpc",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "aws-cdk-lib": "2.172.0",
         "cdk-nag": "^2.34.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "aws-vpc",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.171.1",
-        "cdk-nag": "^2.34.12",
+        "aws-cdk-lib": "2.172.0",
+        "cdk-nag": "^2.34.18",
         "constructs": "^10.4.2",
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.7"
       },
       "bin": {
         "aws-vpc": "bin/aws-vpc.js"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.1",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.171.1",
+        "aws-cdk": "2.172.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.171.1",
-        "aws-cdk-lib": "2.171.1",
+        "aws-cdk": "2.172.0",
+        "aws-cdk-lib": "2.172.0",
         "constructs": "^10.4.2"
       }
     },
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.171.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.171.1.tgz",
-      "integrity": "sha512-IWENyT4F5UcLr1szLsbipUdjIHn8FD3d/RvaIvhs2+qCamkfEV5mqv/ChMvRJ8H2jebhIZ2iz74or9O5Ismp+Q==",
+      "version": "2.172.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.172.0.tgz",
+      "integrity": "sha512-kacztcAl12F6zlBqKCuzCZmj4vrbMhzgDAxBB4T7fXR2amQyuu6W0nWcGWWvASXeBJcw2DJ6ulpfV4wuc9dksw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.171.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.171.1.tgz",
-      "integrity": "sha512-BmXodHmeOWu7EZMwXFA+Mp+SnlZgIwhMxfOmqpdGa5dXF4BWOrs0cm4YgrzcJkg0XK713eXPj5IWGj8YeRIU3g==",
+      "version": "2.172.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.172.0.tgz",
+      "integrity": "sha512-SbFn2FyKhsHQpS7M3qeMWnRKtBHELkY3rmejk07cPlJ/BCJk/af8eKyeiNEEB0AZSfIeP4ImZCLNy9JS34mlPw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1894,9 +1894,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.34.12",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.12.tgz",
-      "integrity": "sha512-81Be6u+MXA0vbR0TfSCkw5OSoYSZK/7WMZUjF/0nRqc7q1fLLpwetEaNUU7xsx1j97aIIN0ehH5NOXtbA0k7tQ==",
+      "version": "2.34.18",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.18.tgz",
+      "integrity": "sha512-Sg6eQ6C+WGTutdy5zw80tdevVZDcK50zijz7DFAOpb6gFeTl2/YsPH/YgQFMuX3Au/RfHRhhQadkh2GUdSpAxA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",
@@ -2144,9 +2144,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.1",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.171.1",
+    "aws-cdk": "2.172.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.171.1",
-    "cdk-nag": "^2.34.12",
+    "aws-cdk-lib": "2.172.0",
+    "cdk-nag": "^2.34.18",
     "constructs": "^10.4.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.171.1",
-    "aws-cdk-lib": "2.171.1",
+    "aws-cdk": "2.172.0",
+    "aws-cdk-lib": "2.172.0",
     "constructs": "^10.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-vpc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },


### PR DESCRIPTION
### **PR Type**
Dependencies


___

### **PR Description**
- Upgraded `aws-cdk` from version `2.171.1` to `2.172.0`
- Updated `cdk-nag` from version `2.34.12` to `2.34.18`
- Updated `dotenv` from version `16.4.5` to `16.4.7`
- Incremented project version from `0.1.0` to `0.1.1`

