### PR TITLE
Update AWS CDK dependencies and increment project version


### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-vpc",
       "version": "0.1.4",
       "dependencies": {
-        "aws-cdk-lib": "2.173.4",
+        "aws-cdk-lib": "2.174.0",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -19,17 +19,17 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.10.2",
+        "@types/node": "22.10.5",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.173.4",
+        "aws-cdk": "2.174.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.173.4",
-        "aws-cdk-lib": "2.173.4",
+        "aws-cdk": "2.174.0",
+        "aws-cdk-lib": "2.174.0",
         "constructs": "^10.4.2"
       }
     },
@@ -66,14 +66,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "38.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
-      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "version": "39.1.38",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.1.38.tgz",
+      "integrity": "sha512-T5nc7+y3pmfXD/LNft1mA8E8Q6IdsE0mta5nC1FZu5sQd+LUo9xGd0BwdzJpR54cgTW/bNcIs5ARoc6kWoRJaA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.4.1",
         "semver": "^7.6.3"
@@ -1136,11 +1135,10 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1286,11 +1284,10 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.173.4",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.4.tgz",
-      "integrity": "sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==",
+      "version": "2.174.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.174.0.tgz",
+      "integrity": "sha512-RN9Y/+MBht0xBwFVKSOwEGBSf/8Q31zwZmRkH9psWHpW24NbB9/frICRqIiWFqiedlNdLdjYkcwP2U4V6Ud6AQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -1302,9 +1299,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.173.4",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.4.tgz",
-      "integrity": "sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==",
+      "version": "2.174.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.174.0.tgz",
+      "integrity": "sha512-OHBJcsg0i4KftWVeUzw1AkG7onZWNNM/DH7NQnbDOs0Ap716VvtcTUubUpeFrazDWe9Opfn1essTjv6gaVyHBw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1318,12 +1315,11 @@
         "yaml",
         "mime-types"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.208",
         "@aws-cdk/asset-kubectl-v20": "^2.1.3",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^38.0.1",
+        "@aws-cdk/cloud-assembly-schema": "^39.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -3907,7 +3903,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-vpc",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-vpc",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "aws-cdk-lib": "2.174.0",
         "cdk-nag": "^2.34.23",
@@ -3903,6 +3903,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.10.2",
+    "@types/node": "22.10.5",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.173.4",
+    "aws-cdk": "2.174.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.4",
+    "aws-cdk-lib": "2.174.0",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.173.4",
-    "aws-cdk-lib": "2.173.4",
+    "aws-cdk": "2.174.0",
+    "aws-cdk-lib": "2.174.0",
     "constructs": "^10.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-vpc",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },


### PR DESCRIPTION
### **PR Type**
Dependencies, Configuration

___

### **PR Description**
- Updated `aws-cdk` and `aws-cdk-lib` dependencies to version `2.174.0`.

- Updated `@types/node` dependency from `22.10.2` to `22.10.5`.

- Incremented project version from `0.1.4` to `0.1.5` in `package.json`.

- Ensured compatibility with the latest AWS CDK release.
