### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2025-01-10 [*](https://github.com/OpenWorkspace-o1/aws-vpc/pull/23)
+
+### Changed
+- Unified `removalPolicy` logic in `AwsVpcStack` for consistent behavior across environments.
+- Updated `aws-cdk` and `aws-cdk-lib` dependencies from `2.174.0` to `2.175.0`.
+- Updated `typescript` dependency from `~5.7.2` to `~5.7.3`.
+
+### Updated
+- Updated `peerDependencies` for `aws-cdk` and `aws-cdk-lib` to version `2.175.0`.
+
 ## 2024-12-29 [*](https://github.com/OpenWorkspace-o1/aws-vpc/pull/19)
 
 ### Changed

--- a/lib/aws-vpc-stack.ts
+++ b/lib/aws-vpc-stack.ts
@@ -26,6 +26,8 @@ export class AwsVpcStack extends cdk.Stack {
     // print out VPC CIDR
     console.log(`VPC CIDR: ${props.VPC_CIDR}`);
 
+    const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
+
     const owVpc = new ec2.Vpc(this, vpcName, {
             ipAddresses: ec2.IpAddresses.cidr(props.VPC_CIDR), //IPs in Range - 65,536
             natGateways: props.NAT_GATEWAYS, // Isolated Subnets do not route traffic to the Internet (in this VPC), and as such, do not require NAT gateways.
@@ -45,18 +47,18 @@ export class AwsVpcStack extends cdk.Stack {
             enableDnsHostnames: true,
             enableDnsSupport: true,
     });
-    owVpc.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    owVpc.applyRemovalPolicy(removalPolicy);
 
     // apply removal policy to all vpc and subnet resources
-    owVpc.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+    owVpc.applyRemovalPolicy(removalPolicy);
     for (const subnet of owVpc.privateSubnets) {
-        subnet.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+        subnet.applyRemovalPolicy(removalPolicy);
     }
     for (const subnet of owVpc.isolatedSubnets) {
-        subnet.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+        subnet.applyRemovalPolicy(removalPolicy);
     }
     for (const subnet of owVpc.publicSubnets) {
-        subnet.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+        subnet.applyRemovalPolicy(removalPolicy);
     }
 
     const vpcFlowLogRole = new iam.Role(this, `${props.resourcePrefix}-RoleVpcFlowLogs`, {
@@ -93,12 +95,12 @@ export class AwsVpcStack extends cdk.Stack {
 
     const vpcFlowLogGroup = new logs.LogGroup(this, `${props.resourcePrefix}-VpcFlowLogGroup`, {
         retention: logs.RetentionDays.ONE_MONTH,
-        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        removalPolicy: removalPolicy,
     });
 
     new logs.LogStream(this, `${props.resourcePrefix}-VpcFlowLogStream`, {
         logGroup: vpcFlowLogGroup,
-        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        removalPolicy: removalPolicy,
     });
 
     new ec2.FlowLog(this, `${props.resourcePrefix}-VpcFlowLog`, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-vpc",
       "version": "0.1.5",
       "dependencies": {
-        "aws-cdk-lib": "2.174.0",
+        "aws-cdk-lib": "2.175.0",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.5",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.174.0",
+        "aws-cdk": "2.175.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript": "~5.7.2"
+        "typescript": "~5.7.3"
       },
       "peerDependencies": {
-        "aws-cdk": "2.174.0",
-        "aws-cdk-lib": "2.174.0",
+        "aws-cdk": "2.175.0",
+        "aws-cdk-lib": "2.175.0",
         "constructs": "^10.4.2"
       }
     },
@@ -1284,10 +1284,11 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.174.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.174.0.tgz",
-      "integrity": "sha512-RN9Y/+MBht0xBwFVKSOwEGBSf/8Q31zwZmRkH9psWHpW24NbB9/frICRqIiWFqiedlNdLdjYkcwP2U4V6Ud6AQ==",
+      "version": "2.175.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.175.0.tgz",
+      "integrity": "sha512-vWMI/DRicvqH+yfOE0ykZolZwn/U9oRvpt1GyoNx1USS/NWc/60Pico9zx8Ui6fc1fYK3ow+Gwl3p/Cch9uscQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -1299,9 +1300,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.174.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.174.0.tgz",
-      "integrity": "sha512-OHBJcsg0i4KftWVeUzw1AkG7onZWNNM/DH7NQnbDOs0Ap716VvtcTUubUpeFrazDWe9Opfn1essTjv6gaVyHBw==",
+      "version": "2.175.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.175.0.tgz",
+      "integrity": "sha512-QZddiS+kFv7SuQtBTUHscO8BHhd3v3BOLMSe1tMR8dE7XvPhY50p6Amqdo4pI6lZqAJma1wC2SZkHmajzTzgVQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1315,6 +1316,7 @@
         "yaml",
         "mime-types"
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.208",
         "@aws-cdk/asset-kubectl-v20": "^2.1.3",
@@ -4263,9 +4265,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.5",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.174.0",
+    "aws-cdk": "2.175.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.174.0",
+    "aws-cdk-lib": "2.175.0",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.174.0",
-    "aws-cdk-lib": "2.174.0",
+    "aws-cdk": "2.175.0",
+    "aws-cdk-lib": "2.175.0",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies

___

### **PR Description**
- Unified `removalPolicy` logic in `AwsVpcStack` for consistency.
  - Uses `RETAIN` for production and `DESTROY` otherwise.

- Updated `aws-cdk` and `aws-cdk-lib` dependencies from `2.174.0` to `2.175.0`.

- Updated `typescript` dependency from `~5.7.2` to `~5.7.3`.

- Applied `removalPolicy` consistently across VPC and related resources.
