### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2025-01-11 [*](https://github.com/OpenWorkspace-o1/aws-vpc/pull/27)
+
+### Changed
+- Updated `aws-cdk` and `aws-cdk-lib` dependencies from `2.175.0` to `2.175.1`.
+
+### Updated
+- Updated `peerDependencies` for `aws-cdk` and `aws-cdk-lib` to version `2.175.1`.
+- Incremented project version from `0.1.5` to `0.1.6`.
+
 ## 2025-01-10 [*](https://github.com/OpenWorkspace-o1/aws-vpc/pull/23)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-vpc",
       "version": "0.1.5",
       "dependencies": {
-        "aws-cdk-lib": "2.175.0",
+        "aws-cdk-lib": "2.175.1",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.5",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.175.0",
+        "aws-cdk": "2.175.1",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.3"
       },
       "peerDependencies": {
-        "aws-cdk": "2.175.0",
-        "aws-cdk-lib": "2.175.0",
+        "aws-cdk": "2.175.1",
+        "aws-cdk-lib": "2.175.1",
         "constructs": "^10.4.2"
       }
     },
@@ -1284,9 +1284,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.175.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.175.0.tgz",
-      "integrity": "sha512-vWMI/DRicvqH+yfOE0ykZolZwn/U9oRvpt1GyoNx1USS/NWc/60Pico9zx8Ui6fc1fYK3ow+Gwl3p/Cch9uscQ==",
+      "version": "2.175.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.175.1.tgz",
+      "integrity": "sha512-duvy0FtGAAYqJi/x0MjBfCp60ZlDYl0X5/GrADwMz4AfHQ8aTXCyaVsdJuCxz0ZMHSNaFRuCNkAlc2Xu43zQmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1300,9 +1300,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.175.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.175.0.tgz",
-      "integrity": "sha512-QZddiS+kFv7SuQtBTUHscO8BHhd3v3BOLMSe1tMR8dE7XvPhY50p6Amqdo4pI6lZqAJma1wC2SZkHmajzTzgVQ==",
+      "version": "2.175.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.175.1.tgz",
+      "integrity": "sha512-2OiZDUeuAA5nBrWKxQVT0CHrQmLLx7SIpUeqyKRLEdiYPFlj3nCd/0KcVpsy6hPKS+IZp7Qm1kghmGMsV6JGoA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-vpc",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-vpc",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "aws-cdk-lib": "2.175.1",
         "cdk-nag": "^2.34.23",

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.5",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.175.0",
+    "aws-cdk": "2.175.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.175.0",
+    "aws-cdk-lib": "2.175.1",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.175.0",
-    "aws-cdk-lib": "2.175.0",
+    "aws-cdk": "2.175.1",
+    "aws-cdk-lib": "2.175.1",
     "constructs": "^10.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-vpc",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },


### PR DESCRIPTION
### **PR Type**
Dependencies

___

### **PR Description**
- Updated `aws-cdk` dependency from `2.175.0` to `2.175.1`.

- Updated `aws-cdk-lib` dependency from `2.175.0` to `2.175.1`.

- Updated `peerDependencies` for `aws-cdk` and `aws-cdk-lib` to `2.175.1`.

- Incremented project version from `0.1.5` to `0.1.6`.
