### PR TITLE
Simplify AwsVpcStack name

### DIFF
--- a/bin/aws-vpc.ts
+++ b/bin/aws-vpc.ts
@@ -60,7 +60,7 @@ const stackProps: AwsVpcStackProps = {
 };
 new AwsVpcStack(app, `AwsVpcStack`, {
     ...stackProps,
-    stackName: `${appName}-${deployEnvironment}-${cdkRegion}-AwsVpcStack`,
+    stackName: `${deployEnvironment}-AwsVpcStack`,
     description: `AwsVpcStack for ${appName} in ${cdkRegion} ${deployEnvironment}.`,
 });
 


### PR DESCRIPTION
### **PR Type**
Refactoring

___

### **PR Description**
- Simplified `AwsVpcStack` name by removing redundant `appName` and `cdkRegion` from `stackName`.
