### PR TITLE
`es2022`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": [
-      "es2020",
+      "es2022",
       "dom"
     ],
     "declaration": true,


### PR DESCRIPTION
### **PR Type**
Configuration

___

### **PR Description**
- Updated TypeScript compiler target to `ES2022`.

- Changed library support from `es2020` to `es2022`.
